### PR TITLE
docs: add README and AGENTS.md for all workspace crates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+> **Code is the source of truth.** This file provides guidance for AI agents working on this project.
+> If anything here conflicts with the actual code, trust the code — then update this file to fix the discrepancy.
+> When adding new behavior or changing existing behavior, update the relevant AGENTS.md file(s) as part of the same change.
+
+## Project Overview
+
+This is a Rust implementation of the [MS-SMB2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962) protocol (SMB versions 2 and 3). The MS-SMB2 spec is the authoritative reference for all protocol behavior. Use the [Rust Book](https://doc.rust-lang.org/book/) and `cargo clippy` as the primary references for idiomatic Rust.
+
+## Workspace Structure
+
+| Crate | Path | Purpose |
+|---|---|---|
+| `smb_reader` | `smb/` | Main crate — protocol types, async server, socket layer, auth, crypto |
+| `smb-core` | `smb-core/` | Core traits (`SMBFromBytes`, `SMBToBytes`, `SMBByteSize`), errors, logging macros |
+| `smb-derive` | `smb-derive/` | Procedural derive macros for wire-format serialization |
+
+Each crate has its own `AGENTS.md` with crate-specific guidance.
+
+## Development Rules
+
+### Branch Discipline
+- **Never commit to `main` directly.** Always cut a feature branch before starting work.
+- Open a PR with a clear, accurate description when the work is complete.
+
+### Test Coverage
+- All code changes must be accompanied by tests.
+- When editing existing files, review and add tests where coverage is missing.
+- Never leave changed code untested if tests can reasonably be written.
+
+### Running Tests
+```sh
+cargo test --lib --features server              # Unit tests
+cargo test --test message --features server,anyhow  # Message round-trips
+cargo test --test smbclient --features server,anyhow -- --ignored  # smbclient integration
+```
+
+### Code Style
+- Follow Rust Book conventions for error handling, enums/pattern matching, and traits.
+- Run `cargo clippy --workspace --features server -- -D warnings` before committing.
+- `mod.rs` should only contain request/response types for its directory. Auxiliary types (flags, enums, info types) go in their own files.
+
+### Concurrency / Lock Ordering
+When acquiring locks, follow strict outer-to-inner ordering to prevent deadlocks:
+
+```
+server → connection → session → tree_connect → open
+```
+
+- Always acquire readers before writers.
+- Never invert this ordering.
+
+### Tracing & Logging
+Tracing is feature-gated and fully opt-in. Macros live in `smb_core::logging`.
+
+**Import style** — always at the top of the file:
+```rust
+use smb_core::logging::{trace, debug, info, warn, error};
+```
+
+**Log levels:**
+| Level | Use for |
+|---|---|
+| `error!` | Unrecoverable failures, states that should never happen |
+| `warn!` | Recoverable issues, degraded behavior |
+| `info!` | Significant lifecycle events (server start, session setup complete) |
+| `debug!` | Operational detail (command dispatch, message send/receive) |
+| `trace!` | Verbose/sensitive data — **never in production** (keys, raw buffers, NTLM flags) |
+
+- All sensitive data (keys, crypto material, auth tokens, raw buffers) **must** use `trace!` only.
+- Use structured fields (`command = ?header.command`) rather than format strings.
+- Every new handler or protocol message type should include at least `debug!` logging.
+
+### Feature Flags
+| Feature | Effect |
+|---|---|
+| `server` | Async server (implies `async` → tokio) |
+| `tracing` | Opt-in tracing via `tracing` crate |
+| `logging` | Tracing + `log` crate compatibility |
+
+These are **independent** — `server` does NOT imply `tracing`.
+
+Build with tracing: `--features "server,tracing,anyhow"`
+
+## Keeping AGENTS.md Current
+
+- **Code is always the source of truth.** Never assume AGENTS.md is complete or up-to-date without checking the code.
+- When you find a discrepancy between AGENTS.md and the code, update AGENTS.md.
+- When you add new behavior, patterns, or conventions, update the relevant AGENTS.md as part of the same PR.
+- Do not let AGENTS.md files go stale — treat them as living documentation.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,87 @@
+# smb
+
+A Rust implementation of the [Server Message Block (SMB) Protocol Versions 2 and 3][ms-smb2],
+built from the ground up following the official Microsoft specification.
+
+## Workspace
+
+| Crate | Description |
+|---|---|
+| [`smb`](./smb) | Protocol types, async server, networking, authentication, and cryptography |
+| [`smb-core`](./smb-core) | Core traits (`SMBFromBytes`, `SMBToBytes`, `SMBByteSize`) and error types |
+| [`smb-derive`](./smb-derive) | Procedural derive macros for wire-format serialization/deserialization |
+
+## Building
+
+Requires **Rust nightly** (edition 2024).
+
+```sh
+# Library check
+cargo check --workspace --features server
+
+# Build the server binary
+cargo build -p smb_reader --features server,anyhow
+
+# Build with tracing enabled
+cargo build -p smb_reader --features server,tracing,anyhow
+```
+
+## Running
+
+```sh
+# Default port (50122)
+cargo run -p smb_reader --features server,anyhow
+
+# Custom port
+SMB_PORT=4450 cargo run -p smb_reader --features server,anyhow
+
+# With tracing (default level: info, override with RUST_LOG)
+RUST_LOG=debug cargo run -p smb_reader --features server,tracing,anyhow
+```
+
+The server listens on `127.0.0.1:<port>` and exposes a filesystem share (`test`) and an IPC share.
+
+## Testing
+
+```sh
+# Unit tests
+cargo test --lib --features server
+
+# Integration tests (message serialization round-trips)
+cargo test --test message --features server,anyhow
+
+# Integration tests with smbclient (requires smbclient installed)
+cargo test --test smbclient --features server,anyhow -- --ignored
+```
+
+## CI
+
+GitHub Actions runs on every push:
+
+| Workflow | What it does |
+|---|---|
+| `check.yml` | `cargo check` + `cargo clippy -- -D warnings` |
+| `unit-tests.yml` | `cargo test --lib --features server` |
+| `integration-tests.yml` | Message round-trip tests + smbclient integration tests |
+| `docs.yml` | `cargo doc --workspace --features server --no-deps` |
+
+## Feature Flags
+
+Defined in the `smb` crate:
+
+| Feature | Effect |
+|---|---|
+| `server` | Enables async server (implies `async`) |
+| `async` | Enables tokio runtime |
+| `tracing` | Opt-in distributed tracing via the `tracing` crate |
+| `logging` | Enables tracing + `log` crate compatibility bridge |
+| `anyhow` | Required for the `spin_server_up` binary |
+
+## Specification
+
+This implementation follows the [MS-SMB2][ms-smb2] specification. Related specs:
+
+- [MS-NLMP](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nlmp/) — NTLM authentication
+- [MS-SPNG](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-spng/) — SPNEGO negotiation
+
+[ms-smb2]: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ built from the ground up following the official Microsoft specification.
 
 ## Building
 
-Requires **Rust nightly** (edition 2024).
+Requires **Rust 1.85+** (edition 2024).
 
 ```sh
 # Library check

--- a/smb-core/AGENTS.md
+++ b/smb-core/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md — smb-core
+
+> **Code is the source of truth.** If anything here conflicts with actual code, trust the code and update this file.
+
+## Crate Role
+
+Foundational crate providing the serialization traits, error types, and logging infrastructure used by the entire workspace. This crate has no dependency on the SMB protocol layer or server — it is purely generic.
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `src/lib.rs` | Core traits + macro-generated impls for primitives |
+| `src/error.rs` | `SMBError` enum with all error variants |
+| `src/logging.rs` | Feature-gated logging macros wrapping `tracing` |
+| `src/nt_status.rs` | NT status code constants |
+
+## Traits
+
+The three primary traits (`SMBByteSize`, `SMBFromBytes`, `SMBToBytes`) form the serialization contract. All SMB wire-format types implement these — typically via the derive macros in `smb-derive`, not by hand.
+
+Additional traits handle vectors (`SMBVecByteSize`, `SMBVecFromBytesCnt`, `SMBVecFromBytesLen`) and discriminated enums (`SMBEnumFromBytes`).
+
+## Adding New Trait Impls
+
+If a new primitive or container type needs to be serializable:
+1. Add the impl in `src/lib.rs` (or via the existing macros if it fits the pattern).
+2. Ensure all three traits (`SMBByteSize`, `SMBFromBytes`, `SMBToBytes`) are implemented consistently.
+3. Add unit tests for the new impl.
+
+## Logging Macros
+
+`logging.rs` uses conditional compilation:
+- With `tracing` feature: re-exports `tracing::{trace, debug, info, warn, error, ...}`.
+- Without: defines no-op macros that compile away entirely.
+
+Consumers import via `use smb_core::logging::{...};` — never use `tracing` directly.
+
+## Keeping This File Current
+
+When adding new traits, error variants, or changing the logging infrastructure, update this file as part of the same change.

--- a/smb-core/README.md
+++ b/smb-core/README.md
@@ -1,0 +1,43 @@
+# smb-core
+
+Core traits, error types, and feature-gated logging macros shared across the SMB workspace.
+
+## Traits
+
+| Trait | Purpose |
+|---|---|
+| `SMBByteSize` | Compute the on-wire byte size of a type |
+| `SMBFromBytes` | Parse a `&[u8]` slice into a typed value |
+| `SMBToBytes` | Serialize a value into `Vec<u8>` (little-endian wire format) |
+| `SMBVecByteSize` | Byte size for `Vec<T>` with alignment |
+| `SMBVecFromBytesCnt` | Parse a `Vec<T>` given an element count |
+| `SMBVecFromBytesLen` | Parse a `Vec<T>` given a total byte length |
+| `SMBEnumFromBytes` | Parse a discriminated enum given an external discriminator value |
+
+Built-in implementations are provided for `u8`–`u128`, `[u8; 0]`–`[u8; 32]`, `Uuid`, `String`, and `PhantomData<T>`.
+
+## Error Types
+
+`SMBError` in `error.rs` covers:
+- `SMBParseError` — malformed input during deserialization
+- `SMBCryptoError` — cryptographic operation failures
+- `SMBPreconditionFailedError` — unmet preconditions
+- `SMBIOError` — I/O errors
+- `SMBResponseError` — response generation failures
+- `SMBPayloadTooSmallError` — input buffer too short
+- `SMBServerError` — server-level errors
+
+## Logging
+
+`logging.rs` provides feature-gated macros (`trace!`, `debug!`, `info!`, `warn!`, `error!`, spans) that delegate to the `tracing` crate when the `tracing` feature is enabled, or compile to no-ops when disabled.
+
+## Feature Flags
+
+| Feature | Effect |
+|---|---|
+| `tracing` | Enables `tracing` crate dependency and re-exports logging macros |
+| `logging` | Enables `tracing/log` compatibility (bridges `tracing` events to the `log` crate) |
+
+## NT Status Codes
+
+`nt_status.rs` defines NT status code constants used in SMB2 response headers, following the [MS-ERREF](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/) specification.

--- a/smb-derive/AGENTS.md
+++ b/smb-derive/AGENTS.md
@@ -1,0 +1,43 @@
+# AGENTS.md — smb-derive
+
+> **Code is the source of truth.** If anything here conflicts with actual code, trust the code and update this file.
+
+## Crate Role
+
+Procedural macro crate that generates `smb_core` trait implementations for SMB2/3 wire-format types. This is a `proc-macro = true` crate — it runs at compile time and produces code, not runtime artifacts.
+
+## Key Files
+
+| File | Purpose |
+|---|---|
+| `src/lib.rs` | Four public derive macros + `derive_impl_creator` dispatch |
+| `src/attrs.rs` | Attribute parsing (darling-based) for `smb_*` field annotations |
+| `src/field.rs` | `SMBFieldType` enum — one variant per attribute kind |
+| `src/field_mapping.rs` | Maps struct fields / enum variants to `SMBFieldMapping` |
+| `src/smb_from_bytes.rs` | Code generation for `SMBFromBytes` |
+| `src/smb_to_bytes.rs` | Code generation for `SMBToBytes` |
+| `src/smb_byte_size.rs` | Code generation for `SMBByteSize` |
+| `src/smb_enum_from_bytes.rs` | Code generation for `SMBEnumFromBytes` |
+
+## How It Works
+
+1. `derive_impl_creator` receives a `DeriveInput` and detects whether the input is a struct, numeric enum (`#[repr(uN)]`), or discriminated enum.
+2. It builds a `Vec<SMBFieldMapping>` describing each field's wire-format layout.
+3. The appropriate `CreatorFn` backend (`FromBytesCreator`, `ToBytesCreator`, `ByteSizeCreator`, `EnumFromBytesCreator`) generates the trait impl from the mapping.
+
+## Adding a New Field Attribute
+
+1. Define the attribute struct in `src/attrs.rs` using `darling::FromAttributes`.
+2. Add a variant to `SMBFieldType` in `src/field.rs`.
+3. Update `get_struct_field_mapping` in `src/field_mapping.rs` to recognize the new attribute.
+4. Implement code generation for the new attribute in each of the four `src/smb_*.rs` backends.
+5. Add tests in `tests/macro-test.rs`.
+
+## Testing
+
+- `tests/macro-test.rs` — compile-time + runtime tests for the derive macros.
+- The `smb` crate's `tests/message.rs` provides end-to-end serialization round-trip coverage.
+
+## Keeping This File Current
+
+When adding new attributes, changing code generation logic, or modifying the field mapping pipeline, update this file as part of the same change.

--- a/smb-derive/README.md
+++ b/smb-derive/README.md
@@ -1,0 +1,58 @@
+# smb-derive
+
+Procedural derive macros for serializing and deserializing SMB2/3 wire-format messages as defined in [MS-SMB2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962).
+
+## Derive Macros
+
+| Macro | Trait Implemented | Purpose |
+|---|---|---|
+| `SMBFromBytes` | `smb_core::SMBFromBytes` | Parse `&[u8]` into a typed struct/enum |
+| `SMBToBytes` | `smb_core::SMBToBytes` | Serialize a struct/enum into `Vec<u8>` |
+| `SMBByteSize` | `smb_core::SMBByteSize` | Compute on-wire byte size |
+| `SMBEnumFromBytes` | `smb_core::SMBEnumFromBytes` | Parse a discriminated enum from bytes + discriminator |
+
+## Field Attributes
+
+Each struct field must carry exactly one attribute describing its wire-format mapping:
+
+| Attribute | Description |
+|---|---|
+| `#[smb_direct(start(…))]` | Fixed-size field at a byte offset |
+| `#[smb_buffer(offset(…), length(…))]` | Variable-length `Vec<u8>` located by offset/length pair |
+| `#[smb_vector(count(…) \| length(…), …)]` | `Vec<T>` with count or byte-length descriptor |
+| `#[smb_string(length(…), underlying, …)]` | UTF-8 or UTF-16LE `String` with length descriptor |
+| `#[smb_enum(discriminator(…), start(…))]` | Nested discriminated enum |
+| `#[smb_skip(start, length)]` | Reserved/padding bytes (`PhantomData`) |
+| `#[smb_byte_tag(value)]` | Single-byte sentinel before the struct |
+| `#[smb_string_tag(value)]` | Multi-byte string sentinel |
+
+## Offset Specifiers
+
+Attributes accept offset/length/count specifiers:
+
+- `fixed = N` — compile-time constant byte offset
+- `"current_pos"` — current parse cursor position
+- `inner(start = N, num_type = "u16", subtract = M, min_val = V)` — read value from input at offset N, optionally subtract M (commonly 64 for the SMB2 header size)
+- `"null_terminated"` — scan for a null terminator
+
+## Example
+
+```rust
+#[derive(SMBFromBytes, SMBToBytes, SMBByteSize)]
+#[smb_byte_tag(value = 9)]
+pub struct SMBSessionSetupResponse {
+    #[smb_direct(start(fixed = 2))]
+    session_flags: u16,
+    #[smb_buffer(
+        offset(inner(start = 4, num_type = "u16", subtract = 64, min_val = 72)),
+        length(inner(start = 6, num_type = "u16")),
+    )]
+    buffer: Vec<u8>,
+}
+```
+
+## Supported Input Types
+
+- **Structs** — fields annotated with `smb_*` attributes
+- **`#[repr(uN)]` enums** — numeric enums read as their repr type and converted via `TryFrom`
+- **Discriminated enums** — variants selected by an external discriminator, each with `#[smb_discriminator(value = …)]`

--- a/smb/AGENTS.md
+++ b/smb/AGENTS.md
@@ -1,0 +1,67 @@
+# AGENTS.md — smb (smb_reader)
+
+> **Code is the source of truth.** If anything here conflicts with actual code, trust the code and update this file.
+
+## Crate Role
+
+Main crate implementing the SMB2/3 protocol per [MS-SMB2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962). Contains protocol wire types, async server, networking, auth, and crypto.
+
+## Key Architecture
+
+### Protocol Layer (`src/protocol/`)
+- `header/` — Packet header parsing. Sync and async header variants. Command enum, flags (bitflags), and NT status codes.
+- `body/` — One sub-module per SMB2 command. `mod.rs` contains the top-level `SMBBody` request/response enums that dispatch by command code.
+- `message.rs` — `SMBMessage` wraps header + body. Handles serialization, deserialization, and cryptographic signing.
+
+**Convention:** `mod.rs` in body sub-directories should only hold the request/response types. Flags, enums, and auxiliary info types belong in their own files.
+
+### Server Layer (`src/server/`)
+- Generic over `Connection`, `Session`, `Share`, `Open`, `Lease`, and `AuthProvider` via traits.
+- `SMBServerBuilder` uses the builder pattern to configure and construct a server.
+- `message_handler.rs` dispatches incoming commands to per-command handler logic.
+
+**Lock ordering (critical for deadlock prevention):**
+```
+server → connection → session → tree_connect → open
+```
+Always acquire readers before writers. Never invert this ordering.
+
+### Socket Layer (`src/socket/`)
+- `listener/` — `SMBListener` trait with sync/async TCP implementations.
+- `message_stream/` — `SMBMessageStream` for reading/writing framed SMB messages.
+
+### Utilities (`src/util/`)
+- `auth/` — `AuthProvider` trait. NTLM implementation with full Negotiate → Challenge → Authenticate flow. SPNEGO wrapping via DER/ASN.1.
+- `crypto/` — SMB2/3 signing keys, encryption keys, NTLMv1/v2 response computation, SP800-108 KDF, DES helpers.
+- `flags_helper.rs` — Bitflag manipulation macros.
+
+## Adding a New SMB2 Command
+
+1. Create a sub-directory under `src/protocol/body/` for the command.
+2. Define request and response structs with `#[derive(SMBFromBytes, SMBToBytes, SMBByteSize)]`.
+3. Add variants to `SMBBody` in `src/protocol/body/mod.rs`.
+4. Add handler logic in `src/server/message_handler.rs`.
+5. Add `debug!` logging in the handler at minimum.
+6. Write unit tests for serialization round-trips and handler behavior.
+
+## Tracing
+
+Import macros at the top of the file:
+```rust
+use smb_core::logging::{trace, debug, info, warn, error};
+```
+
+- `trace!` only for sensitive data (keys, raw buffers, NTLM flags).
+- `debug!` for command dispatch, message flow.
+- `info!` for lifecycle events.
+- Structured fields preferred: `command = ?header.command, mid = header.message_id`.
+
+## Tests
+
+- Unit tests: co-located in source files (`#[cfg(test)]` modules).
+- `tests/message.rs` — serialization round-trip tests.
+- `tests/smbclient.rs` — integration tests spawning a real server and driving it with `smbclient`. Marked `#[ignore]`.
+
+## Keeping This File Current
+
+When you add new commands, handlers, server features, or change architectural patterns, update this file as part of the same change. Do not let it go stale.

--- a/smb/README.md
+++ b/smb/README.md
@@ -21,18 +21,23 @@ Built following the [MS-SMB2](https://learn.microsoft.com/en-us/openspecs/window
 
 ### `server`
 
+- `client.rs` — SMB client representation
 - `connection.rs` — Connection state and lifecycle
 - `session.rs` — User session management
 - `tree_connect.rs` — Share connection state
 - `open.rs` — File/directory open handles
 - `lease.rs` — Oplock/lease management
+- `channel.rs` — Multi-channel support
 - `share/` — Filesystem and IPC share abstractions
 - `message_handler.rs` — Command dispatch and response generation
+- `request.rs` — Request representation
 - `preauth_session.rs` — Pre-authentication session state
 - `safe_locked_getter.rs` — Helper for locked access patterns
 
 ### `util`
 
+- `auth/auth_context.rs` — `AuthContext` and `AuthProvider` traits
+- `auth/user.rs` — User representation with credentials
 - `auth/ntlm/` — Full NTLM authentication flow (Negotiate, Challenge, Authenticate)
 - `auth/spnego/` — SPNEGO/DER token wrapping
 - `crypto/` — DES, NTLMv1 extended, NTLMv2, SMB2 signing/encryption keys, SP800-108 KDF

--- a/smb/README.md
+++ b/smb/README.md
@@ -1,0 +1,70 @@
+# smb (smb_reader)
+
+The main crate in the workspace — implements SMB2/3 protocol types, an async server, network transport, authentication (NTLM via SPNEGO), and cryptographic operations.
+
+Built following the [MS-SMB2](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5606ad47-5ee0-437a-817e-70c366052962) specification.
+
+## Modules
+
+| Module | Description |
+|---|---|
+| `protocol` | Wire-format types for SMB2/3 headers, command bodies, and message framing |
+| `server` | Async SMB server — connection, session, tree-connect, open, and lease management |
+| `socket` | TCP listener and message stream abstractions |
+| `util` | Authentication (NTLM/SPNEGO), cryptographic primitives, byte helpers |
+
+### `protocol`
+
+- `header/` — SMB2 packet header (sync/async), command codes, flags, status
+- `body/` — Request/response structures for all SMB2 commands: Negotiate, Session Setup, Tree Connect, Create, Read, Write, Lock, Flush, Close, Query Info, Set Info, Query Directory, Change Notify, Echo, Cancel, Oplock Break, IOCTL, Tree Disconnect, Logoff
+- `message.rs` — Message wrapper with serialization and cryptographic signing
+
+### `server`
+
+- `connection.rs` — Connection state and lifecycle
+- `session.rs` — User session management
+- `tree_connect.rs` — Share connection state
+- `open.rs` — File/directory open handles
+- `lease.rs` — Oplock/lease management
+- `share/` — Filesystem and IPC share abstractions
+- `message_handler.rs` — Command dispatch and response generation
+- `preauth_session.rs` — Pre-authentication session state
+- `safe_locked_getter.rs` — Helper for locked access patterns
+
+### `util`
+
+- `auth/ntlm/` — Full NTLM authentication flow (Negotiate, Challenge, Authenticate)
+- `auth/spnego/` — SPNEGO/DER token wrapping
+- `crypto/` — DES, NTLMv1 extended, NTLMv2, SMB2 signing/encryption keys, SP800-108 KDF
+
+## Binary
+
+The `spin_server_up` binary starts a development SMB server:
+
+```sh
+# Requires features: server, anyhow
+cargo run -p smb_reader --features server,anyhow
+
+# Custom port via environment variable (default: 50122)
+SMB_PORT=4450 cargo run -p smb_reader --features server,anyhow
+```
+
+## Feature Flags
+
+| Feature | Effect |
+|---|---|
+| `server` | Enables async server (implies `async`) |
+| `async` | Enables `tokio`, `tokio-stream`, `tokio-util` |
+| `tracing` | Opt-in distributed tracing + `tracing-subscriber` |
+| `logging` | Tracing + `log` crate compatibility bridge |
+| `anyhow` | Required for the `spin_server_up` binary |
+
+## Tests
+
+Unit tests are co-located in source files. Integration tests live in `tests/`:
+
+| Test file | What it covers |
+|---|---|
+| `tests/message.rs` | Message serialization/deserialization round-trips |
+| `tests/macro.rs` | Procedural macro functionality |
+| `tests/smbclient.rs` | End-to-end tests using the system `smbclient` binary (requires `--ignored`) |


### PR DESCRIPTION
## Summary

- Add `README.md` for root workspace, `smb`, `smb-core`, and `smb-derive` covering build/run/test instructions, module structure, feature flags, and CI overview
- Add `AGENTS.md` for root workspace and all three crates with AI agent guidance: development rules, code conventions, lock ordering, tracing/logging guidelines, and instructions for adding new commands/attributes
- All AGENTS.md files include the directive that **code is the source of truth** — agents must update AGENTS.md when discrepancies are found or behavior changes

## Files Added

| File | Purpose |
|---|---|
| `README.md` | Workspace overview, build/run/test commands, CI, feature flags |
| `AGENTS.md` | Top-level agent guidance: dev rules, tracing, lock ordering, conventions |
| `smb/README.md` | Main crate modules, binary usage, test files |
| `smb/AGENTS.md` | Architecture guide, adding new commands, handler patterns |
| `smb-core/README.md` | Core traits, error types, logging macros |
| `smb-core/AGENTS.md` | Trait contract, adding impls, logging macro usage |
| `smb-derive/README.md` | Derive macros, field attributes, offset specifiers, examples |
| `smb-derive/AGENTS.md` | Code-gen pipeline, adding new attributes, testing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)